### PR TITLE
Fix: Actor-specific duration being overwritten by global setting

### DIFF
--- a/scripts/helpers/animation/crit/critAnimation.js
+++ b/scripts/helpers/animation/crit/critAnimation.js
@@ -31,7 +31,7 @@ export function createCritAnimation(rollDeets, critType, isSuccess = true) {
     config.scale *= imgData.scale;
     config.art = config.art || imgData.img;
     config.sfx = config.sfx || (isSuccess ? getSetting("critical.sound") : "");
-    config.duration = getSetting("critical.duration") * MS_TO_SEC;
+    config.duration = config.duration ?? (getSetting("critical.duration") * MS_TO_SEC);
 
     //Cancels animation based on config or imgData
     if (

--- a/scripts/helpers/animation/crit/critAnimation.js
+++ b/scripts/helpers/animation/crit/critAnimation.js
@@ -31,7 +31,6 @@ export function createCritAnimation(rollDeets, critType, isSuccess = true) {
     config.scale *= imgData.scale;
     config.art = config.art || imgData.img;
     config.sfx = config.sfx || (isSuccess ? getSetting("critical.sound") : "");
-    config.duration = config.duration ?? (getSetting("critical.duration") * MS_TO_SEC);
 
     //Cancels animation based on config or imgData
     if (
@@ -249,7 +248,9 @@ function getCritActorSettings(data, successOrFail, flags, type = "default") {
     result.sfx = typeSpecificSettings?.sfx || baseSettings?.sfx || "";
     result.type = typeSpecificSettings?.type === "default" ? baseSettings?.type : typeSpecificSettings?.type;
     result.imagedelay = (typeSpecificSettings?.imagedelay * MS_TO_SEC) || (baseSettings?.imagedelay ?? 0);
-    result.duration = (typeSpecificSettings?.duration * MS_TO_SEC) || (baseSettings?.duration ?? 1);
+    result.duration = (typeSpecificSettings?.duration !== undefined ? typeSpecificSettings.duration * MS_TO_SEC : null)
+    || (baseSettings?.duration !== undefined ? baseSettings.duration * MS_TO_SEC : null)
+    || data.duration;
 
     const volume =
         (typeSpecificSettings?.volume === 100 ? baseSettings?.volume ?? 100 : typeSpecificSettings?.volume) ?? 100;


### PR DESCRIPTION
The actor-specific duration setting was being overwritten by global settings in `createCritAnimation()`. I changed line 34 to only apply global duration if actor-specific duration isn't already set.