### PR TITLE
Feature: Added critical hit immunity detection with bypass toggle

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -377,6 +377,10 @@
                     "name": "Enable Critical Animations - For You",
                     "hint": "Enable cool animations to show for critical hits for yourself. (Note. actors have options to have alternative image)"
                 },
+                "bypass-immunity": {
+                    "name": "Bypass Immunity",
+                    "hint": "Show critical animations even for creatures immune to critical hits"
+                },
                 "sound": {
                     "name": "Sound",
                     "hint": "Sound to use for critical animation"
@@ -434,6 +438,7 @@
                     "name": "Delay",
                     "hint": "How long to delay when the critical animation shows up in seconds"
                 }
+                
             },
             "burst-burrow": {
                 "enabled": {

--- a/scripts/helpers/animation/crit/critAnimation.js
+++ b/scripts/helpers/animation/crit/critAnimation.js
@@ -81,7 +81,9 @@ function shouldCancelCriticalHit(rollDeets, enabledType) {
     const isAttack = rollDeets.type === "attack-roll";
     const showOn = getSetting("critical.show-on");
 
-    if (isAttack && !getSetting("critical.bypass-immunity")) {
+    if (isAttack && !getSetting("critical.bypass-immunity") && hasTargetCritImmunity(rollDeets.target)) {
+        return true;
+    }
         if (hasTargetCritImmunity(rollDeets.target)) {
             return true;
         }

--- a/scripts/helpers/animation/crit/critAnimation.js
+++ b/scripts/helpers/animation/crit/critAnimation.js
@@ -31,7 +31,7 @@ export function createCritAnimation(rollDeets, critType, isSuccess = true) {
     config.scale *= imgData.scale;
     config.art = config.art || imgData.img;
     config.sfx = config.sfx || (isSuccess ? getSetting("critical.sound") : "");
-    config.duration = getSetting("critical.duration") * MS_TO_SEC;
+    config.duration = config.duration ?? (getSetting("critical.duration") * MS_TO_SEC);
 
     //Cancels animation based on config or imgData
     if (

--- a/scripts/helpers/animation/crit/critAnimation.js
+++ b/scripts/helpers/animation/crit/critAnimation.js
@@ -31,7 +31,6 @@ export function createCritAnimation(rollDeets, critType, isSuccess = true) {
     config.scale *= imgData.scale;
     config.art = config.art || imgData.img;
     config.sfx = config.sfx || (isSuccess ? getSetting("critical.sound") : "");
-    config.duration = config.duration ?? (getSetting("critical.duration") * MS_TO_SEC);
 
     //Cancels animation based on config or imgData
     if (
@@ -249,7 +248,9 @@ function getCritActorSettings(data, successOrFail, flags, type = "default") {
     result.sfx = typeSpecificSettings?.sfx || baseSettings?.sfx || "";
     result.type = typeSpecificSettings?.type === "default" ? baseSettings?.type : typeSpecificSettings?.type;
     result.imagedelay = (typeSpecificSettings?.imagedelay * MS_TO_SEC) || (baseSettings?.imagedelay ?? 0);
-    result.duration = (typeSpecificSettings?.duration * MS_TO_SEC) || (baseSettings?.duration ?? 1);
+    result.duration = (typeSpecificSettings?.duration !== undefined ? typeSpecificSettings.duration * MS_TO_SEC : null)
+    || (baseSettings?.duration !== undefined ? baseSettings.duration * MS_TO_SEC : null)
+    || data.duration;
 
     const volume =
         (typeSpecificSettings?.volume === 100 ? baseSettings?.volume ?? 100 : typeSpecificSettings?.volume) ?? 100;

--- a/scripts/helpers/animation/crit/critAnimation.js
+++ b/scripts/helpers/animation/crit/critAnimation.js
@@ -80,13 +80,9 @@ function shouldCancelCriticalHit(rollDeets, enabledType) {
     
     const isAttack = rollDeets.type === "attack-roll";
     const showOn = getSetting("critical.show-on");
-
+    
     if (isAttack && !getSetting("critical.bypass-immunity") && hasTargetCritImmunity(rollDeets.target)) {
         return true;
-    }
-        if (hasTargetCritImmunity(rollDeets.target)) {
-            return true;
-        }
     }
 
     switch (showOn) {

--- a/scripts/helpers/forms/settingsConfigForm.js
+++ b/scripts/helpers/forms/settingsConfigForm.js
@@ -153,6 +153,7 @@ const settingsConfig = {
         icon: "fas fa-explosion",
         critical: {
             enabled: "critical.enabled",
+            bypassImmunity: "critical.bypass-immunity",
             style: "critical.type",
             checksOrAttacks: "critical.show-on",
             pcOrNPC: "critical.show-on-token-type",

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -190,6 +190,7 @@ export function checkRollNumbers(dat, msg) {
             whisper: msg.whisper,
             roll: msg.rolls[0]?.total ?? "",
             type: msg.flags.pf2e.context.type,
+            target: msg?.flags?.pf2e?.context?.target,
         };
         if (doChecks) {
             generateRollScroll(roll_deets);

--- a/scripts/settings/registerCriticalSettings.js
+++ b/scripts/settings/registerCriticalSettings.js
@@ -15,6 +15,16 @@ export function registerCriticalSettings() {
 
     registerSetting({
         category: "critical",
+        id: "critical.bypass-immunity",
+        desc: "enabled",
+        scope: "world",
+        config: false,
+        default: true,
+        type: Boolean,
+    });
+
+    registerSetting({
+        category: "critical",
         id: "critical.player-enabled",
         desc: "player-enabled",
         scope: "player",

--- a/templates/settings/tabs/critical.hbs
+++ b/templates/settings/tabs/critical.hbs
@@ -22,6 +22,22 @@
         {{checked settings.critical.enabled}}
     />
 </div>
+{{! Bypass Immunity }}
+<div class="form-group">
+    <label
+        for="settings.critical.bypassImmunity"
+        data-tooltip-direction="LEFT"
+        data-tooltip="{{localize "pf2e-rpg-numbers.module-settings.critical.bypass-immunity.hint"}}"
+    >
+        {{localize "pf2e-rpg-numbers.module-settings.critical.bypass-immunity.name"}}
+    </label>
+    <input
+        type="checkbox"
+        id="settings.critical.bypassImmunity"
+        name="settings.critical.bypassImmunity"
+        {{checked settings.critical.bypassImmunity}}
+    />
+</div>
 {{! Style }}
 <div class="form-group">
     <label


### PR DESCRIPTION
Adds detection for creatures with [immunity to critical hits](https://2e.aonprd.com/Rules.aspx?ID=2314)
and adds a `Bypass Immunity` toggle in the Critical Hit settings. It’s enabled by default.
<img width="580" height="576" alt="image" src="https://github.com/user-attachments/assets/117f2326-b9ea-43d0-8122-56447d3121e6" />

https://github.com/user-attachments/assets/5553b9b4-0707-4f56-a0c1-3924292eaf3e

